### PR TITLE
Update Twigcs project path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Install Count](https://vsmarketplacebadge.apphb.com/installs/cerzat43.twigcs.svg)](https://marketplace.visualstudio.com/items?itemName=cerzat43.twigcs)
 [![Open Issues](https://vsmarketplacebadge.apphb.com/rating/cerzat43.twigcs.svg)](https://marketplace.visualstudio.com/items?itemName=cerzat43.twigcs)
 
-Integrates [twigcs](https://github.com/allocine/twigcs) into [Visual Studio Code](https://code.visualstudio.com/).
+Integrates [twigcs](https://github.com/friendsoftwig/twigcs) into [Visual Studio Code](https://code.visualstudio.com/).
 
 ## Setup Development Version
 

--- a/client/README.md
+++ b/client/README.md
@@ -4,7 +4,7 @@
 [![Install Count](https://vsmarketplacebadge.apphb.com/installs/cerzat43.twigcs.svg)](https://marketplace.visualstudio.com/items?itemName=cerzat43.twigcs)
 [![Open Issues](https://vsmarketplacebadge.apphb.com/rating/cerzat43.twigcs.svg)](https://marketplace.visualstudio.com/items?itemName=cerzat43.twigcs)
 
-This linter plugin for [Visual Studio Code](https://code.visualstudio.com/) provides an interface to [twigcs](https://github.com/allocine/twigcs). It will be used with files that have the “Twig” language mode.
+This linter plugin for [Visual Studio Code](https://code.visualstudio.com/) provides an interface to [twigcs](https://github.com/friendsoftwig/twigcs). It will be used with files that have the “Twig” language mode.
 
 ![Twigcs example](twigcs_ex.png)
 
@@ -14,7 +14,7 @@ Visual Studio Code must be installed in order to use this plugin. If Visual Stud
 
 ## Linter Installation
 
-Before using this plugin, you must ensure that [twigcs](https://github.com/allocine/twigcs) is installed on your system. The installation can be performed system-wide / project-wide using [composer](https://getcomposer.org/).
+Before using this plugin, you must ensure that [twigcs](https://github.com/friendsoftwig/twigcs) is installed on your system. The installation can be performed system-wide / project-wide using [composer](https://getcomposer.org/).
 
 Once twigcs is installed, you can proceed to install the vscode-twigcs plugin if it is not yet installed.
 
@@ -26,7 +26,7 @@ The `twigcs` linter can be installed globally using the Composer Dependency Mana
 2. Require `twigcs` package by typing the following in a terminal:
 
 ```bash
-composer global require allocine/twigcs
+composer global require friendsoftwig/twigcs
 ```
 
 ### Project-wide Installation
@@ -37,7 +37,7 @@ The `twigcs` linter can be installed in your project using the Composer Dependen
 2. Require `twigcs` package by typing the following at the root of your project in a terminal:
 
 ```bash
-composer require --dev allocine/twigcs
+composer require --dev friendsoftwig/twigcs
 ```
 
 ### Plugin Installation

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -237,14 +237,14 @@ class TwigcsServer {
         });
       } else {
         this.showErrorMessage(
-          `The 'twigcs' dependency was not found. You may need to update your dependencies using "composer global require allocine/twigcs" or set your twigcs.executablePath manually.`,
+          `The 'twigcs' dependency was not found. You may need to update your dependencies using "composer global require friendsoftwig/twigcs" or set your twigcs.executablePath manually.`,
         );
       }
     }
   }
 
   /**
-   * Convert twigcs diagnostic from allocine for vscode diagnostic.
+   * Convert twigcs diagnostic from friendsoftwig for vscode diagnostic.
    *
    * @param text The text diagnostic from twigcs.
    * @return diagnostics Diagnostic[]


### PR DESCRIPTION
Changes proposed in this pull request:
* Update the Twigcs project path from `allocine/twigcs` to [friendsoftwig/twigcs](https://github.com/friendsoftwig/twigcs)

The development of Twigcs was recently moved to a new repository (see https://github.com/friendsoftwig/twigcs/pull/68 for more information)